### PR TITLE
Add optional route config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,5 @@ when you hit `/ding`, the route will reply with
 The following options are available when registering the plugin:
 - _'path'_ - the path where the route will be registered.  Default is /ding.
 - _'objectName'_ - the name of the object returned.  Can be a string or `false` to put the properties at the root level.  Defaults to "ding".
+- _'config'_ - optional [Hapi route options](http://hapijs.com/api#route-options) to be merged with the defaults.  Defaults to `{ auth: false }`.
 - _'otherData'_ - static object to be merged with the info object.  Defaults to `null`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,11 +7,13 @@ var Hoek = require('hoek');
 var internals = {
   defaults: {
     path: '/ding',
-    objectName: 'ding'
+    objectName: 'ding',
+    config: { auth: false }
   },
   options: Joi.object({
     path: Joi.string().optional(),
     objectName: Joi.string().optional().allow(null, false),
+    config: Joi.object().optional(),
     otherData: Joi.object().optional()
   })
 };
@@ -28,7 +30,7 @@ exports.register = function(plugin, options, next){
   plugin.route({
     method: 'GET',
     path: settings.path,
-    config: { auth: false },
+    config: settings.config,
     handler: function(req, reply) {
       var res = {
         cpu: OS.loadavg(),

--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,14 @@ describe('Registration', function(){
     });
   });
 
+  it('should let you set config options', function(done){
+    server.register({register: require('../'), options: {config: {description: 'Custom Hapi Ding'}}}, function() {
+      var routes = server.table();
+      expect(routes[0].table[0].settings.description).to.equal('Custom Hapi Ding');
+      done();
+    });
+  });
+
   it('should not let you set unknown options', function(done){
     server.register({register: require('../'), options: {badName: {foo: 'bar'}}}, function(err) {
       expect(err).to.not.be.null();


### PR DESCRIPTION
This PR includes the following:
- Ability to set additional [Hapi route options](http://hapijs.com/api#route-options) in the plugin options
- Unit test
- Updated README